### PR TITLE
db: unify every target on storage/development.sqlite3 + ship storage/.keep

### DIFF
--- a/bin/rh
+++ b/bin/rh
@@ -440,9 +440,9 @@ end
 def post_transpile_ruby(out)
   seed = File.join(fixture_path, 'storage', 'development.sqlite3')
   return unless File.exist?(seed)
-  tmp = File.join(out, 'tmp')
-  FileUtils.mkdir_p(tmp)
-  FileUtils.cp(seed, File.join(tmp, 'blog.sqlite3'))
+  storage = File.join(out, 'storage')
+  FileUtils.mkdir_p(storage)
+  FileUtils.cp(seed, File.join(storage, 'development.sqlite3'))
 end
 
 # The spinel target needs no post-transpile step: the HTTP/WebSocket

--- a/runtime/crystal/server.cr
+++ b/runtime/crystal/server.cr
@@ -54,7 +54,7 @@ module Roundhouse
       db_path : String? = nil,
       port : Int32? = nil,
     ) : Nil
-      resolved_path = db_path || "db/development.sqlite3"
+      resolved_path = db_path || "storage/development.sqlite3"
       resolved_port = port || (ENV["PORT"]?.try(&.to_i) || 3000)
 
       Roundhouse::Db.open_production_db(resolved_path, schema_sql)

--- a/runtime/spinel/scaffold/Makefile
+++ b/runtime/spinel/scaffold/Makefile
@@ -129,13 +129,15 @@ $(STATIC)/icon.svg:
 
 build: $(BUILD)/blog
 
-# Populate tmp/blog.sqlite3 with the demo blog's seed data (db/seed.sql).
-# The binary boots against an empty DB fine (Schema.load! is idempotent),
-# but a self-contained run/repro wants rows to serve — `make seed` provides
-# them with nothing but sqlite3. Override the path with BLOG_DB=… at runtime.
-seed: tmp/blog.sqlite3
-tmp/blog.sqlite3: db/seed.sql
-	@mkdir -p tmp
+# Populate storage/development.sqlite3 (the Rails-traditional path, and
+# the binary's default when BLOG_DB is unset) with the demo blog's seed
+# data (db/seed.sql). The binary boots against an empty DB fine
+# (Schema.load! is idempotent), but a self-contained run/repro wants rows
+# to serve — `make seed` provides them with nothing but sqlite3. Override
+# the path with BLOG_DB=… at runtime.
+seed: storage/development.sqlite3
+storage/development.sqlite3: db/seed.sql
+	@mkdir -p storage
 	sqlite3 $@ < db/seed.sql
 
 # spinel AOT-compiles main.rb (+ its whole require graph) straight to a

--- a/runtime/spinel/scaffold/README.md
+++ b/runtime/spinel/scaffold/README.md
@@ -295,22 +295,25 @@ from this fixture:
 ### Persistence
 
 - **Tests use `:memory:` SQLite** — single-process, start fresh.
-  The dev server writes to `tmp/blog.sqlite3` (configurable via
-  `BLOG_DB`) so state survives across requests within one dev-server
-  run. `:memory:` and `tmp/blog.sqlite3` are both gitignored and
-  discarded between sessions. There's no backup, no migration system,
-  no schema versioning.
+  The server defaults to the Rails-traditional
+  `storage/development.sqlite3` (override via `BLOG_DB`) so state
+  survives across requests. The archive ships `storage/.keep` so the
+  directory exists on first run; the seeded DB itself is rebuilt with
+  `make seed` (or `sqlite3 storage/development.sqlite3 < db/seed.sql`)
+  and is discarded between sessions. There's no backup, no migration
+  system, no schema versioning.
 - **End-to-end demo seeds from `fixtures/real-blog`'s
   Rails-populated SQLite.** `bin/rh transpile ruby` copies real-blog's
   `storage/development.sqlite3` (populated by `bin/rails db:prepare` →
-  `db/seeds.rb`) into the demo's `tmp/blog.sqlite3`. Rails-generated
-  schema (varchar/text/datetime affinities) reads + writes through
-  `SqliteAdapter` transparently. `bin/rh clean ruby` resets the demo
-  to its seeded state.
+  `db/seeds.rb`) into the demo's `storage/development.sqlite3`. Rails-
+  generated schema (varchar/text/datetime affinities) reads + writes
+  through `SqliteAdapter` transparently. `bin/rh clean ruby` resets the
+  demo to its seeded state.
 - **`:memory:` SQLite loses everything on process exit.** Used by
-  `make run` (single-shot CGI), tests, and the spinel-compiled binary
-  in the unset-`BLOG_DB` fallback path. Fine for ephemeral scenarios;
-  point `BLOG_DB` at a file for persistence.
+  tests, which configure it explicitly. `make run` (single-shot CGI)
+  and the server's unset-`BLOG_DB` default both now open
+  `storage/development.sqlite3`; pass `BLOG_DB=:memory:` for an
+  ephemeral run.
 - **No transactions, no foreign-key enforcement at DB level**, no
   prepared-statement caching, no connection pooling. The application
   doesn't need them; production wouldn't be served by this stack.

--- a/runtime/spinel/scaffold/main.rb
+++ b/runtime/spinel/scaffold/main.rb
@@ -146,16 +146,17 @@ module Main
   # setup).
   #
   # When `BLOG_DB` env var names a path, configure SqliteAdapter
-  # against that file — required for the dev server, which forks a
-  # fresh CGI process per request and would otherwise lose all data
-  # between requests. Without BLOG_DB, fall back to `:memory:` — works
-  # for the spinel-compiled binary (FFI sqlite is universal) and the
-  # one-shot CGI invocation, and is per-process (no persistence across
-  # forks, which is fine for both).
+  # against that file. Otherwise default to the Rails-traditional
+  # `storage/development.sqlite3` — persisted across requests and
+  # consistent with every other target's default. The archive ships
+  # `storage/.keep`, so the directory exists for first-run open.
+  # Tests configure `:memory:` explicitly through their own setup, so
+  # this server default never reaches them (the `adapter.nil?` guard
+  # also short-circuits when a test already configured the adapter).
   def self.configure_default_adapter!
     return unless ActiveRecord.adapter.nil?
     db_path = ENV["BLOG_DB"]
-    path = (!db_path.nil? && !db_path.empty?) ? db_path : ":memory:"
+    path = (!db_path.nil? && !db_path.empty?) ? db_path : "storage/development.sqlite3"
     # SqliteAdapter.configure delegates to Db.configure (single shared
     # connection); both the legacy AR-adapter dispatch path and the
     # Level-3 lowerer-emitted `_adapter_*` path read through one handle.

--- a/runtime/spinel/scaffold/ruby_overlay/Rakefile
+++ b/runtime/spinel/scaffold/ruby_overlay/Rakefile
@@ -108,12 +108,13 @@ task :assets => [
 # Override with env vars: RAILS_MAX_THREADS=5 WEB_CONCURRENCY=2 PORT=4000.
 desc "Start Puma on :3000 (override PORT, WEB_CONCURRENCY, RAILS_MAX_THREADS)"
 task :dev => :assets do
-  # Default to the seeded SQLite file produced by `make ruby-transpile`
-  # so the demo opens with three articles + seven comments. Override
-  # with BLOG_DB=:memory: for an empty start, or any file path.
+  # Default to the seeded SQLite file (`make seed`, Rails-traditional
+  # storage/development.sqlite3) so the demo opens with three articles
+  # + seven comments. Override with BLOG_DB=:memory: for an empty
+  # start, or any file path.
   env = {
     "RUBYOPT" => "--yjit",
-    "BLOG_DB" => ENV.fetch("BLOG_DB", "tmp/blog.sqlite3"),
+    "BLOG_DB" => ENV.fetch("BLOG_DB", "storage/development.sqlite3"),
   }
   sh(env, "bundle exec puma -C config/puma.rb config.ru")
 end
@@ -138,7 +139,7 @@ task :bench => :assets do
 
   # Boot puma in the background. Caller must `rake bench:setup` (or
   # equivalent) to ensure a clean DB / fresh seed. For now, just
-  # assume tmp/blog.sqlite3 exists with seed data.
+  # assume storage/development.sqlite3 exists with seed data.
   pid = spawn({
     "PORT" => port.to_s,
     "RAILS_ENV" => "production",

--- a/runtime/spinel/scaffold/ruby_overlay/main.rb
+++ b/runtime/spinel/scaffold/ruby_overlay/main.rb
@@ -238,16 +238,17 @@ module Main
   # setup).
   #
   # When `BLOG_DB` env var names a path, configure SqliteAdapter
-  # against that file — required for the dev server, which forks a
-  # fresh CGI process per request and would otherwise lose all data
-  # between requests. Without BLOG_DB, fall back to `:memory:` — works
-  # for the spinel-compiled binary (FFI sqlite is universal) and the
-  # one-shot CGI invocation, and is per-process (no persistence across
-  # forks, which is fine for both).
+  # against that file. Otherwise default to the Rails-traditional
+  # `storage/development.sqlite3` — persisted across requests and
+  # consistent with every other target's default. The archive ships
+  # `storage/.keep`, so the directory exists for first-run open.
+  # Tests configure `:memory:` explicitly through their own setup, so
+  # this server default never reaches them (the `adapter.nil?` guard
+  # also short-circuits when a test already configured the adapter).
   def self.configure_default_adapter!
     return unless ActiveRecord.adapter.nil?
     db_path = ENV["BLOG_DB"]
-    path = (!db_path.nil? && !db_path.empty?) ? db_path : ":memory:"
+    path = (!db_path.nil? && !db_path.empty?) ? db_path : "storage/development.sqlite3"
     # SqliteAdapter.configure delegates to Db.configure (single shared
     # connection); both the legacy AR-adapter dispatch path and the
     # Level-3 lowerer-emitted `_adapter_*` path read through one handle.

--- a/runtime/typescript/server-libsql.ts
+++ b/runtime/typescript/server-libsql.ts
@@ -443,7 +443,7 @@ export type ControllerClass = new () => any;
 
 export interface StartOptions {
   /** libsql URL or local file path. Defaults to
-   *  `./db/development.sqlite3` (interpreted as `file:` URL). For
+   *  `./storage/development.sqlite3` (interpreted as `file:` URL). For
    *  Turso remote DBs, pass `libsql://<host>` or set via
    *  `TURSO_DATABASE_URL` env var; auth tokens go through the
    *  client constructor and are out of scope for this minimal
@@ -473,7 +473,7 @@ const sessionStore: Record<string, any> = {};
  *  awaits the libsql DB open + schema apply before binding the
  *  HTTP listener. */
 export async function startServer(opts: StartOptions): Promise<void> {
-  const dbPath = opts.dbPath ?? "./db/development.sqlite3";
+  const dbPath = opts.dbPath ?? "./storage/development.sqlite3";
   const port = opts.port ?? Number(process.env.PORT ?? 3000);
 
   layoutRenderer = opts.layout ?? null;

--- a/runtime/typescript/server.ts
+++ b/runtime/typescript/server.ts
@@ -498,8 +498,8 @@ async function attachCable(
 
 function openDatabase(dbPath: string, schemaStatements: string[]): void {
   // better-sqlite3 creates the file if it doesn't exist, but
-  // NOT the parent directory — if we're opening `./db/
-  // development.sqlite3` and `./db/` doesn't exist, the
+  // NOT the parent directory — if we're opening `./storage/
+  // development.sqlite3` and `./storage/` doesn't exist, the
   // constructor throws. Create intermediate dirs so first-run
   // startup works without the user having to mkdir manually.
   // In-memory DBs (`:memory:`) don't have a parent dir; skip.
@@ -561,7 +561,7 @@ export type RouteRow = RouteClass;
 export type ControllerClass = new () => any;
 
 export interface StartOptions {
-  /** File path for the sqlite DB. Defaults to `./db/development.sqlite3`. */
+  /** File path for the sqlite DB. Defaults to `./storage/development.sqlite3`. */
   dbPath?: string;
   /** HTTP port. Defaults to 3000 or `PORT` env var. */
   port?: number;
@@ -611,7 +611,7 @@ const sessionStore: Record<string, any> = {};
 /** Start the server. Returns a promise that resolves once the
  *  HTTP + WebSocket listeners are accepting connections. */
 export async function startServer(opts: StartOptions): Promise<void> {
-  const dbPath = opts.dbPath ?? "./db/development.sqlite3";
+  const dbPath = opts.dbPath ?? "./storage/development.sqlite3";
   const port = opts.port ?? Number(process.env.PORT ?? 3000);
 
   layoutRenderer = opts.layout ?? null;

--- a/scripts/bench
+++ b/scripts/bench
@@ -613,25 +613,25 @@ stage_db() {
             sqlite3 "$dev" ".backup $prod"
             ;;
         ruby|ruby-int)
-            local db="$RUBY_OUT/tmp/blog.sqlite3"
+            local db="$RUBY_OUT/storage/development.sqlite3"
             mkdir -p "$(dirname "$db")"
             rm -f "$db" "$db-wal" "$db-shm"
             sqlite3 "$FIXTURE/storage/development.sqlite3" ".backup $db"
             ;;
         jruby)
-            local db="$JRUBY_OUT/tmp/blog.sqlite3"
+            local db="$JRUBY_OUT/storage/development.sqlite3"
             mkdir -p "$(dirname "$db")"
             rm -f "$db" "$db-wal" "$db-shm"
             sqlite3 "$FIXTURE/storage/development.sqlite3" ".backup $db"
             ;;
         typescript)
-            local db="$TS_OUT/db/development.sqlite3"
+            local db="$TS_OUT/storage/development.sqlite3"
             mkdir -p "$(dirname "$db")"
             rm -f "$db" "$db-wal" "$db-shm"
             sqlite3 "$FIXTURE/storage/development.sqlite3" ".backup $db"
             ;;
         crystal)
-            local db="$CR_OUT/db/development.sqlite3"
+            local db="$CR_OUT/storage/development.sqlite3"
             mkdir -p "$(dirname "$db")"
             rm -f "$db" "$db-wal" "$db-shm"
             sqlite3 "$FIXTURE/storage/development.sqlite3" ".backup $db"
@@ -655,7 +655,7 @@ stage_db() {
             sqlite3 "$FIXTURE/storage/development.sqlite3" ".backup $db"
             ;;
         spinel)
-            local db="$SP_OUT/tmp/blog.sqlite3"
+            local db="$SP_OUT/storage/development.sqlite3"
             mkdir -p "$(dirname "$db")"
             rm -f "$db" "$db-wal" "$db-shm"
             sqlite3 "$FIXTURE/storage/development.sqlite3" ".backup $db"
@@ -750,7 +750,7 @@ start_target() {
         ruby)
             (cd "$RUBY_OUT" && \
                 BUNDLE_GEMFILE="$TARGET_GEMFILE" \
-                BLOG_DB=tmp/blog.sqlite3 \
+                BLOG_DB=storage/development.sqlite3 \
                 RAILS_MAX_THREADS="$THREADS" \
                 WEB_CONCURRENCY="$workers" \
                 RAILS_ENV=production \
@@ -764,7 +764,7 @@ start_target() {
         ruby-int)
             (cd "$RUBY_OUT" && \
                 BUNDLE_GEMFILE="$TARGET_GEMFILE" \
-                BLOG_DB=tmp/blog.sqlite3 \
+                BLOG_DB=storage/development.sqlite3 \
                 RAILS_MAX_THREADS="$THREADS" \
                 WEB_CONCURRENCY="$workers" \
                 RAILS_ENV=production \
@@ -791,7 +791,7 @@ start_target() {
             # measurements — a host-dependent artifact, not a footprint.
             (cd "$JRUBY_OUT" && \
                 BUNDLE_GEMFILE="$JRUBY_OUT/Gemfile" \
-                BLOG_DB=tmp/blog.sqlite3 \
+                BLOG_DB=storage/development.sqlite3 \
                 RAILS_MAX_THREADS="$THREADS" \
                 WEB_CONCURRENCY=0 \
                 RAILS_ENV=production \
@@ -869,7 +869,7 @@ start_target() {
             # once, so a smaller pool would make fibers park on a handle.
             # Same DATABASE_POOL_SIZE knob the rust target reads.
             (cd "$SP_OUT" && \
-                BLOG_DB=tmp/blog.sqlite3 \
+                BLOG_DB=storage/development.sqlite3 \
                 PORT="$port" \
                 DATABASE_POOL_SIZE="$CONNECTIONS" \
                 ./build/blog \

--- a/scripts/compare
+++ b/scripts/compare
@@ -168,7 +168,7 @@ TARGET_LOG="$LOG_DIR/target.log"
 case "$TARGET" in
     typescript)
         BUILD_DIR="/tmp/rh-ts-pass2"
-        DB_DEST="$BUILD_DIR/db/development.sqlite3"
+        DB_DEST="$BUILD_DIR/storage/development.sqlite3"
         ;;
     rust)
         BUILD_DIR="/tmp/rh-rs-pass2"
@@ -184,7 +184,7 @@ case "$TARGET" in
         ;;
     crystal)
         BUILD_DIR="/tmp/rh-cr-pass2"
-        DB_DEST="$BUILD_DIR/db/development.sqlite3"
+        DB_DEST="$BUILD_DIR/storage/development.sqlite3"
         ;;
     kotlin)
         BUILD_DIR="/tmp/rh-kt-pass2"
@@ -201,26 +201,25 @@ case "$TARGET" in
     ruby)
         # Ruby reuses the demo's transpile output (`bin/rh transpile
         # ruby`), which lives under build/transpiled-blog-ruby/. The
-        # dev server reads BLOG_DB; the staged DB lands at
-        # tmp/blog.sqlite3 inside that tree.
+        # dev server reads BLOG_DB; the staged DB lands at the Rails-
+        # traditional storage/development.sqlite3 inside that tree.
         BUILD_DIR="$REPO_ROOT/build/transpiled-blog-ruby"
-        DB_DEST="$BUILD_DIR/tmp/blog.sqlite3"
+        DB_DEST="$BUILD_DIR/storage/development.sqlite3"
         ;;
     jruby)
         # JRuby reuses `bin/rh transpile jruby` — byte-identical emit to
         # the ruby tree but with the JDBC db backend. Same DB layout
-        # (BLOG_DB → tmp/blog.sqlite3) inside its own build dir.
+        # (BLOG_DB → storage/development.sqlite3) inside its own build dir.
         BUILD_DIR="$REPO_ROOT/build/transpiled-blog-jruby"
-        DB_DEST="$BUILD_DIR/tmp/blog.sqlite3"
+        DB_DEST="$BUILD_DIR/storage/development.sqlite3"
         ;;
     spinel)
         # Spinel uses `bin/rh transpile spinel`, which mirrors the
-        # ruby path but additionally vendors the Tep transport
-        # (sphttp.c → .o + @TEP_SPHTTP_O@ substitution in net.rb).
-        # The AOT-compiled binary reads BLOG_DB and serves over
-        # Tep::Server on $PORT; same DB layout as the ruby target.
+        # ruby path but compiles main.rb to a native binary. The
+        # AOT-compiled binary reads BLOG_DB and serves over Tep::Server
+        # on $PORT; same DB layout as the ruby target.
         BUILD_DIR="$REPO_ROOT/build/transpiled-blog-spinel"
-        DB_DEST="$BUILD_DIR/tmp/blog.sqlite3"
+        DB_DEST="$BUILD_DIR/storage/development.sqlite3"
         ;;
 esac
 
@@ -502,7 +501,7 @@ if [[ -z "$TARGET_CMD" ]]; then
             # (both supplied by ruby_overlay). BLOG_DB points at the
             # staged seeded SQLite; BUNDLE_GEMFILE points at the
             # scaffold's Gemfile so CI's bundler-cache is reused.
-            (cd "$BUILD_DIR" && BLOG_DB=tmp/blog.sqlite3 BUNDLE_GEMFILE="$REPO_ROOT/runtime/spinel/scaffold/Gemfile" PORT="$TARGET_PORT" bundle exec puma -C config/puma.rb >"$TARGET_LOG" 2>&1) &
+            (cd "$BUILD_DIR" && BLOG_DB="$DB_DEST" BUNDLE_GEMFILE="$REPO_ROOT/runtime/spinel/scaffold/Gemfile" PORT="$TARGET_PORT" bundle exec puma -C config/puma.rb >"$TARGET_LOG" 2>&1) &
             TARGET_PID=$!
             ;;
         jruby)
@@ -510,7 +509,7 @@ if [[ -z "$TARGET_CMD" ]]; then
             # (WEB_CONCURRENCY=0 — Puma cluster mode forks, unsupported on
             # the JVM); its own tree Gemfile drives the JRuby bundle. Heap
             # pinned to 512 MB to match the bench harness (-Xmx==-Xms).
-            (cd "$BUILD_DIR" && BLOG_DB=tmp/blog.sqlite3 BUNDLE_GEMFILE="$BUILD_DIR/Gemfile" WEB_CONCURRENCY=0 PORT="$TARGET_PORT" JRUBY_OPTS="-J-Xmx512m -J-Xms512m" jruby -S bundle exec puma -C config/puma.rb >"$TARGET_LOG" 2>&1) &
+            (cd "$BUILD_DIR" && BLOG_DB="$DB_DEST" BUNDLE_GEMFILE="$BUILD_DIR/Gemfile" WEB_CONCURRENCY=0 PORT="$TARGET_PORT" JRUBY_OPTS="-J-Xmx512m -J-Xms512m" jruby -S bundle exec puma -C config/puma.rb >"$TARGET_LOG" 2>&1) &
             TARGET_PID=$!
             ;;
         typescript)
@@ -522,7 +521,7 @@ if [[ -z "$TARGET_CMD" ]]; then
             TARGET_PID=$!
             ;;
         spinel)
-            (cd "$BUILD_DIR" && BLOG_DB=tmp/blog.sqlite3 PORT="$TARGET_PORT" ./build/blog >"$TARGET_LOG" 2>&1) &
+            (cd "$BUILD_DIR" && BLOG_DB="$DB_DEST" PORT="$TARGET_PORT" ./build/blog >"$TARGET_LOG" 2>&1) &
             TARGET_PID=$!
             ;;
     esac

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -144,14 +144,12 @@ ok "extracted ($APP_DIR)"
 
 # -------- 3. seed (Ruby-free) --------
 
-# Per-target DB path. Each target creates its schema on boot
-# (idempotent), and db/seed.sql's CREATE TABLE IF NOT EXISTS makes the
-# seed self-sufficient against a fresh empty file.
-case "$TARGET" in
-    go|rust|python|elixir|kotlin|swift)  DB_REL="storage/development.sqlite3" ;;
-    typescript|crystal)     DB_REL="db/development.sqlite3" ;;
-    ruby|jruby|spinel)      DB_REL="tmp/blog.sqlite3" ;;
-esac
+# DB path — now uniform across every target: the Rails-traditional
+# storage/development.sqlite3 (archives ship storage/.keep so the dir
+# exists). Each target creates its schema on boot (idempotent), and
+# db/seed.sql's CREATE TABLE IF NOT EXISTS makes the seed self-sufficient
+# against a fresh empty file.
+DB_REL="storage/development.sqlite3"
 step "seeding $DB_REL from db/seed.sql"
 mkdir -p "$APP_DIR/$(dirname "$DB_REL")"
 rm -f "$APP_DIR/$DB_REL" "$APP_DIR/$DB_REL-wal" "$APP_DIR/$DB_REL-shm"

--- a/src/project.rs
+++ b/src/project.rs
@@ -189,7 +189,7 @@ pub fn target_readme(target: BuildTarget) -> String {
              ```\n\n\
              ## Run\n\
              ```sh\n\
-             BLOG_DB=tmp/blog.sqlite3 ./build/blog\n\
+             ./build/blog\n\
              ```\n\n\
              ## Test\n\
              ```sh\n\
@@ -220,7 +220,7 @@ pub fn target_readme(target: BuildTarget) -> String {
              ```\n\n\
              ## Run\n\
              ```sh\n\
-             BLOG_DB=tmp/blog.sqlite3 bundle exec puma -C config/puma.rb\n\
+             bundle exec puma -C config/puma.rb\n\
              ```\n\n\
              ## Test\n\
              ```sh\n\
@@ -251,7 +251,7 @@ pub fn target_readme(target: BuildTarget) -> String {
              ```\n\n\
              ## Run\n\
              ```sh\n\
-             BLOG_DB=tmp/blog.sqlite3 WEB_CONCURRENCY=0 jruby -S bundle exec puma -C config/puma.rb\n\
+             WEB_CONCURRENCY=0 jruby -S bundle exec puma -C config/puma.rb\n\
              ```\n\n\
              ## Test\n\
              ```sh\n\
@@ -422,6 +422,31 @@ pub fn target_readme(target: BuildTarget) -> String {
              runs in a `SharedWorker` context.\n"
         }
     };
+    // Inject a uniform `## Setup` step before `## Run`, for every target
+    // that ships a DB-backed server (`ships_e2e`). It seeds the Rails-
+    // traditional `storage/development.sqlite3` from the bundled
+    // `db/seed.sql`, which is self-contained (CREATE TABLE IF NOT EXISTS
+    // + INSERT) so it runs standalone — no build/boot first — and
+    // `storage/.keep` (shipped by `ensure_storage_keep`) guarantees the
+    // directory exists. scripts/smoke executes this block (it skips only
+    // Run / Regenerate), so the previously-untested human setup path is
+    // now CI-covered.
+    let body = if ships_e2e(target) {
+        body.replacen(
+            "## Run\n",
+            "## Setup\n\
+             Seed the database — the Rails-traditional \
+             `storage/development.sqlite3`, from the bundled `db/seed.sql` \
+             (needs the `sqlite3` CLI):\n\
+             ```sh\n\
+             sqlite3 storage/development.sqlite3 < db/seed.sql\n\
+             ```\n\n\
+             ## Run\n",
+            1,
+        )
+    } else {
+        body.to_string()
+    };
     // Every server target serves the same blog with the same env
     // conventions (PORT, default 3000; Action Cable at /cable), so
     // the "what you get" sentence lives here, not per target. Blog
@@ -530,6 +555,7 @@ pub fn target_files(
         files
     } else {
         let files = ensure_seed_sql(files)?;
+        let files = ensure_storage_keep(files, target);
         let files = ensure_static_assets(files, target);
         ensure_e2e(files, target)
     };
@@ -608,10 +634,10 @@ fn ensure_e2e(
     // boot, not compilation.
     let (boot, db_rel) = match target {
         BuildTarget::Go => ("./server", "storage/development.sqlite3"),
-        BuildTarget::Typescript => ("npm start", "db/development.sqlite3"),
+        BuildTarget::Typescript => ("npm start", "storage/development.sqlite3"),
         BuildTarget::Rust => ("./target/release/app", "storage/development.sqlite3"),
         BuildTarget::Python => ("uv run python -m app", "storage/development.sqlite3"),
-        BuildTarget::Crystal => ("./server", "db/development.sqlite3"),
+        BuildTarget::Crystal => ("./server", "storage/development.sqlite3"),
         // mix.exs declares no `mod:` (the app doesn't auto-start), so
         // the entry point must be explicit — bare `mix run --no-halt`
         // starts the BEAM and nothing else.
@@ -624,22 +650,22 @@ fn ensure_e2e(
             "storage/development.sqlite3",
         ),
         BuildTarget::Swift => ("./.build/debug/App", "storage/development.sqlite3"),
-        // BLOG_DB must be explicit: bare puma (without the rake dev
-        // task's env defaulting) falls back to :memory: and the seed
-        // file is never opened.
+        // The server now defaults to storage/development.sqlite3 (Rails-
+        // traditional) when BLOG_DB is unset, so the boot command is bare —
+        // seed.js seeds that same path before this runs.
         BuildTarget::Ruby => (
-            "BLOG_DB=tmp/blog.sqlite3 bundle exec puma -C config/puma.rb",
-            "tmp/blog.sqlite3",
+            "bundle exec puma -C config/puma.rb",
+            "storage/development.sqlite3",
         ),
         BuildTarget::Jruby => (
-            "BLOG_DB=tmp/blog.sqlite3 WEB_CONCURRENCY=0 jruby -S bundle exec puma -C config/puma.rb",
-            "tmp/blog.sqlite3",
+            "WEB_CONCURRENCY=0 jruby -S bundle exec puma -C config/puma.rb",
+            "storage/development.sqlite3",
         ),
-        // The AOT binary (built by the README's `make build`) reads BLOG_DB
-        // (else falls back to :memory:) and PORT (default 3000, which the
-        // playwright config expects). Serves /assets/* from the prebuilt
-        // static/assets/ via sphttp sendfile.
-        BuildTarget::Spinel => ("BLOG_DB=tmp/blog.sqlite3 ./build/blog", "tmp/blog.sqlite3"),
+        // The AOT binary (built by the README's `make build`) defaults to
+        // storage/development.sqlite3 when BLOG_DB is unset, and reads PORT
+        // (default 3000, which the playwright config expects). Serves
+        // /assets/* from the prebuilt static/assets/.
+        BuildTarget::Spinel => ("./build/blog", "storage/development.sqlite3"),
         _ => unreachable!("ships_e2e gates the match"),
     };
 
@@ -879,8 +905,9 @@ fn blog_files(fixture: &Path) -> Result<Vec<(String, String)>, String> {
 ///      from the fixture verbatim. Binary files are silently
 ///      skipped (text-only archive).
 ///
-/// The seeded `tmp/blog.sqlite3` that the Makefile copies in is NOT
-/// included — `Schema.load!` is idempotent so a fresh DB still boots.
+/// The seeded `storage/development.sqlite3` that `bin/rh` stages in is
+/// NOT included — `Schema.load!` is idempotent so a fresh DB still boots
+/// (the archive ships `storage/.keep` so the directory exists).
 fn ruby_runtime_files(
     app: &App,
     fixture: &Path,
@@ -1103,6 +1130,27 @@ fn ensure_seed_sql(files: Vec<(String, String)>) -> Result<Vec<(String, String)>
     files.push(("db/seed.sql".to_string(), content));
     files.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(files)
+}
+
+/// Ship an empty `storage/.keep` so the Rails-traditional
+/// `storage/development.sqlite3` always has a parent directory in the
+/// extracted archive. The server's default DB path (BLOG_DB unset) and
+/// the README's `## Setup` step (`sqlite3 storage/development.sqlite3 <
+/// db/seed.sql`) both open that path, and sqlite creates the *file* but
+/// not the *directory* — without `.keep` the first open fails with
+/// `SQLITE_CANTOPEN`. Only DB-backed server archives (`ships_e2e`) need
+/// it; TypescriptWorker/Blog have no server. No-op if already present.
+fn ensure_storage_keep(
+    files: Vec<(String, String)>,
+    target: BuildTarget,
+) -> Vec<(String, String)> {
+    if !ships_e2e(target) || files.iter().any(|(p, _)| p == "storage/.keep") {
+        return files;
+    }
+    let mut files = files;
+    files.push(("storage/.keep".to_string(), String::new()));
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
 }
 
 /// Resolve duplicate paths by keeping the last-inserted entry, then


### PR DESCRIPTION
## Problem

Following the spinel README's `## Run` (`BLOG_DB=tmp/blog.sqlite3 ./build/blog`) failed with sqlite **`SQLITE_CANTOPEN (14)`**. sqlite creates the DB *file* but not its parent *directory*, and a fresh archive shipped no `tmp/`. CI never caught it: `scripts/smoke` skips the `## Run` block, and `e2e/seed.js` `mkdirSync`s before booting — so the bare human run path was the one thing untested.

While fixing it, the DB path was inconsistent across targets:
- `storage/development.sqlite3` — go, rust, python, elixir, kotlin, swift
- `db/development.sqlite3` — typescript, crystal
- `tmp/blog.sqlite3` — ruby, jruby, spinel (the outliers)

## Change — every demo gets the same Rails-traditional setup

- **Ship an empty `storage/.keep`** in every DB-backed archive (`ensure_storage_keep`) so the dir always exists for first-run open.
- **Default every target to `storage/development.sqlite3`**: `server.ts`/`server-libsql.ts`, `server.cr`, and the ruby-family `main.rb` (was `:memory:` on unset `BLOG_DB` → now the file, so bare `./build/blog`/`puma` "just work"; tests still pass `:memory:` explicitly).
- **Uniform `## Setup` step** — `sqlite3 storage/development.sqlite3 < db/seed.sql` — injected before `## Run` in every README. It's its own section, so **`scripts/smoke` now runs it**, closing the CI-vs-human gap that hid this bug. Ruby-family run commands drop the `BLOG_DB=` prefix.
- **Harnesses/tooling updated to match**: `scripts/compare` (CI-critical), `scripts/e2e`, `scripts/bench`, `bin/rh` (stages the seed into `storage/`), scaffold `Makefile`/`Rakefile`, SPECIMEN docs.

## Verification

- `cargo build` clean; **815 tests pass, 0 fail**.
- Regenerated spinel/typescript/crystal/go/ruby: ship `storage/.keep`, `## Setup` before `## Run`, no stale `tmp/blog`·`db/development` paths; ruby's Setup lands between Build and Run; typescript-worker correctly excluded.
- Runtime: booted the existing spinel binary against `storage/development.sqlite3` → HTTP 200 with seeded articles, **no error 14**.

`spinel` isn't on PATH in the dev env, so the AOT build + full smoke for spinel are left to CI (this PR triggers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)