### PR TITLE
ts: upgrade assert_select Dom from substring stub to linkedom

### DIFF
--- a/runtime/typescript/minitest-async.ts
+++ b/runtime/typescript/minitest-async.ts
@@ -18,6 +18,7 @@
 
 import { test as nodeTest } from "node:test";
 import assert from "node:assert/strict";
+import { parseHTML } from "linkedom";
 
 // minitest-async.ts is emitted to `test/_runtime/`; `router.ts` and
 // `flash.ts` are emitted to `src/`. Two levels up.
@@ -226,50 +227,32 @@ const RESPONSE_SYMBOLS: Record<string, number> = {
   missing: 404,
 };
 
-/** Turn a loose selector into a substring fragment that probably
- *  appears in matching HTML. `#id` → `id="id"`, `.class` →
- *  `class"`, bare tag → `<tag`. Compound selectors split and pick
- *  the first chunk. */
-function selectorFragment(selector: string): string {
-  const first = selector.split(/\s+/)[0] ?? "";
-  if (first.startsWith("#")) return `id="${first.slice(1)}"`;
-  if (first.startsWith(".")) return `${first.slice(1)}"`;
-  return `<${first}`;
-}
-
 // ── Dom primitive surface (the assert_select substrate) ────────────
 //
-// The HTML-query contract `assert_select` lowers to, shared in shape
-// with the Ruby/Python/Rust/Elixir twins (cross-target contract in
-// runtime/spinel/test/test_helper.rbs). Stub: the substring matcher
-// dressed as a Dom — `select` fabricates one synthetic node (the whole
-// document) per fragment occurrence and `text` returns it verbatim.
-// The upgrade path is to swap these three methods for a cheerio/
-// linkedom-backed engine — real nodes, real CSS selectors — touching
-// only this object; the assert_select call site stays put.
+// Backed by linkedom: a real, worker-bundle-able DOM + CSS selector
+// engine (css-select), exposed through the cross-target contract
+// (runtime/spinel/test/test_helper.rbs). `parse` builds a document,
+// `select` runs a real CSS query, `text` reads an element's
+// textContent — so `assert_select` does genuine structural matching
+// instead of substring guessing. linkedom is the one engine that runs
+// in BOTH execution contexts this runtime targets: the node test
+// runner (installed from package.json) and the browser SharedWorker /
+// studio (bundled as a CDN external — see wasm/lib/bundle.mjs). jsdom
+// is node-only and can't bundle into a worker; css-select covers every
+// selector assert_select needs. Typed `any` at the boundary to avoid
+// global-lib-DOM vs linkedom-DOM type friction.
 const Dom = {
-  // Parse an HTML document. Stub: the document *is* its html string.
-  parse(html: string): string {
-    return html ?? "";
+  // Parse an HTML document into a queryable root.
+  parse(html: string): any {
+    return parseHTML(html ?? "").document;
   },
-  // Nodes matching `selector` within `root` (a document or node). Stub:
-  // one synthetic node (the root's html) per substring-fragment
-  // occurrence.
-  select(root: string, selector: string): string[] {
-    const fragment = selectorFragment(selector);
-    const nodes: string[] = [];
-    let from = 0;
-    for (;;) {
-      const i = root.indexOf(fragment, from);
-      if (i < 0) break;
-      nodes.push(root);
-      from = i + fragment.length;
-    }
-    return nodes;
+  // Elements matching `selector` within `root` (a document or element).
+  select(root: any, selector: string): any[] {
+    return Array.from(root.querySelectorAll(selector));
   },
-  // Concatenated descendant text of a node. Stub: the node verbatim.
-  text(node: string): string {
-    return node;
+  // An element's concatenated descendant text.
+  text(node: any): string {
+    return node.textContent ?? "";
   },
 };
 

--- a/runtime/typescript/minitest.ts
+++ b/runtime/typescript/minitest.ts
@@ -16,6 +16,7 @@
 
 import { test as nodeTest } from "node:test";
 import assert from "node:assert/strict";
+import { parseHTML } from "linkedom";
 
 // minitest.ts is emitted to `test/_runtime/`; `router.ts` and
 // `flash.ts` are emitted to `src/`. Two levels up.
@@ -278,50 +279,32 @@ const RESPONSE_SYMBOLS: Record<string, number> = {
   missing: 404,
 };
 
-/** Turn a loose selector into a substring fragment that probably
- *  appears in matching HTML. `#id` → `id="id"`, `.class` →
- *  `class"`, bare tag → `<tag`. Compound selectors split and pick
- *  the first chunk. */
-function selectorFragment(selector: string): string {
-  const first = selector.split(/\s+/)[0] ?? "";
-  if (first.startsWith("#")) return `id="${first.slice(1)}"`;
-  if (first.startsWith(".")) return `${first.slice(1)}"`;
-  return `<${first}`;
-}
-
 // ── Dom primitive surface (the assert_select substrate) ────────────
 //
-// The HTML-query contract `assert_select` lowers to, shared in shape
-// with the Ruby/Python/Rust/Elixir twins (cross-target contract in
-// runtime/spinel/test/test_helper.rbs). Stub: the substring matcher
-// dressed as a Dom — `select` fabricates one synthetic node (the whole
-// document) per fragment occurrence and `text` returns it verbatim.
-// The upgrade path is to swap these three methods for a cheerio/
-// linkedom-backed engine — real nodes, real CSS selectors — touching
-// only this object; the assert_select call site stays put.
+// Backed by linkedom: a real, worker-bundle-able DOM + CSS selector
+// engine (css-select), exposed through the cross-target contract
+// (runtime/spinel/test/test_helper.rbs). `parse` builds a document,
+// `select` runs a real CSS query, `text` reads an element's
+// textContent — so `assert_select` does genuine structural matching
+// instead of substring guessing. linkedom is the one engine that runs
+// in BOTH execution contexts this runtime targets: the node test
+// runner (installed from package.json) and the browser SharedWorker /
+// studio (bundled as a CDN external — see wasm/lib/bundle.mjs). jsdom
+// is node-only and can't bundle into a worker; css-select covers every
+// selector assert_select needs. Typed `any` at the boundary to avoid
+// global-lib-DOM vs linkedom-DOM type friction.
 const Dom = {
-  // Parse an HTML document. Stub: the document *is* its html string.
-  parse(html: string): string {
-    return html ?? "";
+  // Parse an HTML document into a queryable root.
+  parse(html: string): any {
+    return parseHTML(html ?? "").document;
   },
-  // Nodes matching `selector` within `root` (a document or node). Stub:
-  // one synthetic node (the root's html) per substring-fragment
-  // occurrence.
-  select(root: string, selector: string): string[] {
-    const fragment = selectorFragment(selector);
-    const nodes: string[] = [];
-    let from = 0;
-    for (;;) {
-      const i = root.indexOf(fragment, from);
-      if (i < 0) break;
-      nodes.push(root);
-      from = i + fragment.length;
-    }
-    return nodes;
+  // Elements matching `selector` within `root` (a document or element).
+  select(root: any, selector: string): any[] {
+    return Array.from(root.querySelectorAll(selector));
   },
-  // Concatenated descendant text of a node. Stub: the node verbatim.
-  text(node: string): string {
-    return node;
+  // An element's concatenated descendant text.
+  text(node: any): string {
+    return node.textContent ?? "";
   },
 };
 

--- a/src/emit/typescript/package.rs
+++ b/src/emit/typescript/package.rs
@@ -28,7 +28,7 @@ pub(super) fn emit_package_json() -> EmittedFile {
         )
     };
     let content = format!(
-        "{{\n  \"name\": \"app\",\n  \"version\": \"0.1.0\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"scripts\": {{\n    \"start\": \"tsx main.ts\",\n    \"test\": \"tsx --test test/*.test.ts\"\n  }},\n  \"dependencies\": {{\n{db_dep}\n    \"ws\": \"^8.18.0\"\n  }},\n  \"devDependencies\": {{\n    \"@types/node\": \"^20\",\n{db_types_dep}    \"@types/ws\": \"^8.5.0\",\n    \"typescript\": \"5.7.3\",\n    \"tsx\": \"4.19.2\"\n  }}\n}}\n",
+        "{{\n  \"name\": \"app\",\n  \"version\": \"0.1.0\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"scripts\": {{\n    \"start\": \"tsx main.ts\",\n    \"test\": \"tsx --test test/*.test.ts\"\n  }},\n  \"dependencies\": {{\n{db_dep}\n    \"linkedom\": \"^0.18.0\",\n    \"ws\": \"^8.18.0\"\n  }},\n  \"devDependencies\": {{\n    \"@types/node\": \"^20\",\n{db_types_dep}    \"@types/ws\": \"^8.5.0\",\n    \"typescript\": \"5.7.3\",\n    \"tsx\": \"4.19.2\"\n  }}\n}}\n",
     );
     EmittedFile {
         path: PathBuf::from("package.json"),
@@ -53,7 +53,8 @@ fn emit_worker_package_json() -> EmittedFile {
   },
   \"dependencies\": {
     \"@hotwired/turbo\": \"^8.0.0\",
-    \"@sqlite.org/sqlite-wasm\": \"^3.47.0-build1\"
+    \"@sqlite.org/sqlite-wasm\": \"^3.47.0-build1\",
+    \"linkedom\": \"^0.18.0\"
   },
   \"devDependencies\": {
     \"@tailwindcss/vite\": \"^4.0.0\",

--- a/wasm/lib/bundle.mjs
+++ b/wasm/lib/bundle.mjs
@@ -24,6 +24,11 @@ const ESBUILD_BASE = `https://cdn.jsdelivr.net/npm/esbuild-wasm@${ESBUILD_VERSIO
 export const DEFAULT_CDN = {
   "@hotwired/turbo": "https://esm.sh/@hotwired/turbo@8",
   "@sqlite.org/sqlite-wasm": "https://esm.sh/@sqlite.org/sqlite-wasm@3.47.0-build1",
+  // assert_select's Dom engine in the worker-bundled test runtime
+  // (runtime/typescript/minitest-async.ts). esm.sh ships linkedom with
+  // its transitive deps (htmlparser2, css-select) pre-bundled into one
+  // worker-safe ESM, so it resolves as an external URL like the others.
+  "linkedom": "https://esm.sh/linkedom@0.18",
 };
 
 // The worker-profile entry points (relative to the emitted project root).


### PR DESCRIPTION
## What

Replaces the TypeScript `Dom` primitive's **substring-matching stub** with a real HTML parser + CSS selector engine (**linkedom** → `css-select`), in both runtime variants (`minitest.ts` sync, `minitest-async.ts` async). This is the first concrete engine upgrade against the `Dom` contract landed in #55 — touching only the three `Dom` methods, no `assert_select` call site changes, no other target affected.

```ts
const Dom = {
  parse(html) { return parseHTML(html ?? "").document; },
  select(root, selector) { return Array.from(root.querySelectorAll(selector)); },
  text(node) { return node.textContent ?? ""; },
};
```

So `assert_select` now does **genuine structural matching** instead of substring guessing — e.g. `#comments .p-4` actually checks the descendant relation, and text/count checks read the matched element rather than scanning the whole body.

## Why linkedom (not jsdom)

linkedom is the one engine that runs in **both** contexts this runtime targets:
- the **node test runner** (toolchain / framework-tests), and
- the **browser SharedWorker / studio** (browser-smoke).

jsdom is node-only and won't bundle into a worker. linkedom and cheerio share `css-select`; linkedom maps 1:1 onto the contract (`document`/`querySelectorAll`/`textContent`). I [verified empirically](https://github.com/rubys/roundhouse) that linkedom's `css-select` resolves every selector the blog tests use — and well beyond (`:has`, `:is`, `:nth-*`, attribute, state pseudos) — correctly.

## Wiring (two resolution paths)

- **node profiles** (sync + async): `linkedom` added to the emitted `package.json` dependencies → resolved by `npm install`.
- **worker profile**: `linkedom` added to the studio bundler's CDN allowlist (`wasm/lib/bundle.mjs` `DEFAULT_CDN` → `esm.sh`, which ships linkedom + `htmlparser2`/`css-select` pre-bundled into one worker-safe ESM), exactly like `@hotwired/turbo` and `@sqlite.org/sqlite-wasm`. The in-browser `esbuild-wasm` has no `node_modules`, so npm deps resolve as **CDN externals** rather than being inlined.

Boundary types are `any` to avoid global-lib-DOM vs linkedom-DOM type friction under the emitted tsconfig (`strict: false`, `skipLibCheck: true`).

## Verification

- **node-async (libsql) toolchain — passes locally**: `tsc` resolves linkedom and `node --test` runs the real blog controller tests with `assert_select` going through linkedom's DOM. This exercises `minitest-async.ts`, the file the worker shares.
- **default `cargo test`** green (61 ok / 0 failed) — the `worker_target_emit` / `async_coloring_emit` package.json assertions accept the new dep.
- `parseHTML("")` handles empty bodies (0 matches, no throw).
- **sync-node (better-sqlite3)** — native build unavailable in the dev sandbox; the `Dom` code is byte-identical to the verified async file. Confirmed by CI (`toolchain-typescript`, `framework-tests-typescript`).
- **worker** — the esm.sh CDN resolution in the SharedWorker is confirmed by CI (`browser-smoke-typescript`).

## Scope

TypeScript only. Other targets keep their stub until upgraded with their idiomatic engine (Nokogiri/scraper/goquery/…), independently, per the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)